### PR TITLE
feat: replace busybox telnetd with inetutils-telnetd via socat

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,19 @@
+// Project markdownlint configuration
+// Matches global ~/.markdownlint.jsonc settings
+{
+  "default": true,
+
+  // Disabled rules
+  "MD013": false,
+  "MD033": false,
+  "MD041": false,
+
+  // Rule configurations
+  "MD012": {
+    "maximum": 1
+  },
+  "MD040": {
+    "allowed_languages": [],
+    "language_only": false
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,271 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when
+working with code in this repository.
+
+## Project Overview
+
+This is an SSH Test Server project - a fully configurable
+Docker-based SSH server designed specifically for integration
+testing, development, and SSH client validation. The project
+provides a comprehensive testing environment for SSH connections
+with multiple authentication methods and security configurations.
+
+## Architecture
+
+The system is built around a Docker container that runs OpenSSH
+server with full runtime configurability:
+
+- **Base**: Alpine Linux 3.19 for minimal footprint
+- **SSH Server**: OpenSSH with comprehensive configuration options
+- **Runtime Configuration**: All settings controlled via environment variables
+- **Security**: Non-root execution, configurable authentication restrictions
+- **Testing**: Comprehensive test suite with integration tests
+
+### Key Components
+
+- `docker/Dockerfile`: Multi-stage Docker build configuration
+- `docker/entrypoint.sh`: Runtime configuration script that
+  generates sshd_config
+- `scripts/test-connection.sh`: Basic SSH connection testing
+- `scripts/test-auth-methods.sh`: Authentication methods testing
+- `tests/integration/run-tests.sh`: Comprehensive integration test suite
+- `examples/docker-compose.yml`: Multiple deployment configurations
+
+## Common Development Commands
+
+### Building and Running
+
+```bash
+# Build Docker image
+make build
+# Or: docker build -f docker/Dockerfile -t ssh-test-server:dev .
+
+# Run basic container
+make run
+# Or: docker run -d --name ssh-test-dev -p 2222:22 \
+#   -e SSH_USER=testuser -e SSH_PASSWORD=testpass123 \
+#   ssh-test-server:dev
+
+# Run with debug mode
+make run-debug
+
+# Run with telnet enabled
+make run-telnet
+# Or: docker run -d --name ssh-test-dev -p 2222:22 -p 2323:23 \
+#   -e SSH_USER=testuser -e SSH_PASSWORD=testpass123 \
+#   -e TELNET_ENABLED=yes ssh-test-server:debian
+
+# View logs
+make logs
+# Or: docker logs -f ssh-test-dev
+
+# Get shell access
+make shell
+# Or: docker exec -it ssh-test-dev /bin/sh
+```
+
+### Testing Commands
+
+```bash
+# Run comprehensive integration tests
+make test
+# Or: ./tests/integration/run-tests.sh --image ssh-test-server:dev
+
+# Run tests in parallel
+make test-parallel
+
+# Test basic connection
+make test-connection
+# Or: ./scripts/test-connection.sh --host localhost \
+#   --port 2222 --user testuser --password testpass123
+
+# Test authentication methods
+make test-auth
+# Or: ./scripts/test-auth-methods.sh \
+#   --container ssh-test-dev --user testuser --generate-keys
+
+# Run full CI pipeline locally
+make ci-full
+```
+
+### Docker Compose Profiles
+
+```bash
+# Basic password authentication
+docker-compose --profile basic up -d
+
+# Public key authentication only  
+docker-compose --profile pubkey up -d
+
+# Security hardened configuration
+docker-compose --profile hardened up -d
+
+# Development setup with volume mounts
+docker-compose --profile dev up -d
+```
+
+### Apple Container Commands (macOS with Apple Silicon)
+
+Apple Container is a native macOS tool for running Linux
+containers. All Docker commands can be replaced with `container`
+for Apple Silicon Macs running macOS 26+.
+
+**First-time setup required:**
+
+```bash
+# Start the container system (one-time setup, will prompt to install kernel)
+container system start
+```
+
+```bash
+# Build image (using Docker buildx, then use with container)
+make build
+
+# Run basic container
+container run -d --name ssh-test-dev -p 2222:22 \
+  -e SSH_USER=testuser -e SSH_PASSWORD=testpass123 \
+  ghcr.io/billchurch/ssh_test:alpine
+
+# Run with debug mode
+container run -d --name ssh-test-debug -p 2222:22 \
+  -e SSH_USER=testuser -e SSH_PASSWORD=testpass123 \
+  -e SSH_DEBUG_LEVEL=3 \
+  ghcr.io/billchurch/ssh_test:alpine
+
+# View logs
+container logs -f ssh-test-dev
+
+# Get shell access
+container exec -it ssh-test-dev /bin/sh
+
+# Check container status
+container ps
+
+# Health check
+container inspect ssh-test-dev | grep -A5 Health
+
+# Cleanup
+container stop ssh-test-dev && container rm ssh-test-dev
+
+# Test connection (same as Docker)
+ssh -p 2222 testuser@localhost
+
+# Run tests against Apple Container
+./tests/integration/run-tests.sh --container ssh-test-dev
+```
+
+**Note**: Apple Container requires macOS 26 (latest beta) and
+Apple Silicon. All testing scripts work identically with
+containers started by either Docker or Apple Container.
+
+### Development Workflow
+
+```bash
+# Full development cycle
+make dev  # Clean, build, and run for development
+
+# Check container status
+make status
+
+# Health check
+make health
+
+# Generate test SSH keys
+make generate-keys
+
+# Cleanup
+make clean
+```
+
+## Configuration System
+
+The SSH server is entirely configured through environment variables at runtime:
+
+### Authentication Configuration
+
+- `SSH_USER`: Username to create (required)
+- `SSH_PASSWORD`: Password for authentication (required even
+  for key-only auth to unlock account)
+- `SSH_AUTHORIZED_KEYS`: SSH public keys (newline separated)
+- `SSH_PERMIT_PASSWORD_AUTH`: Enable/disable password auth (yes/no)
+- `SSH_PERMIT_PUBKEY_AUTH`: Enable/disable public key auth (yes/no)
+- `SSH_CHALLENGE_RESPONSE_AUTH`: Enable keyboard-interactive auth (yes/no)
+
+**Important**: Always set `SSH_PASSWORD` even when using only
+public key authentication. Without a password, the user account
+may remain locked and prevent key-based authentication from
+working.
+
+### Security Configuration
+
+- `SSH_PERMIT_ROOT_LOGIN`: Allow root login (yes/no)
+- `SSH_MAX_AUTH_TRIES`: Maximum authentication attempts
+- `SSH_LOGIN_GRACE_TIME`: Login timeout in seconds
+- `SSH_PERMIT_EMPTY_PASSWORDS`: Allow empty passwords (yes/no)
+
+### Network and Debug
+
+- `SSH_PORT`: SSH server port (default: 22)
+- `SSH_DEBUG_LEVEL`: Debug verbosity (0-3)
+- `SSH_USE_DNS`: Enable DNS lookups (yes/no)
+
+### Telnet Configuration
+
+- `TELNET_ENABLED`: Enable telnet server (yes/no, default: no)
+- `TELNET_PORT`: Telnet server port (default: 23)
+
+## Testing Architecture
+
+The project includes a comprehensive testing framework:
+
+### Test Scripts
+
+1. **Basic Connection Test**
+   (`scripts/test-connection.sh`): Tests connectivity and
+   basic SSH functionality
+2. **Authentication Methods Test**
+   (`scripts/test-auth-methods.sh`): Comprehensive
+   authentication testing with key generation
+3. **Integration Test Suite**
+   (`tests/integration/run-tests.sh`): Full integration
+   tests with parallel execution support
+
+### Test Scenarios Covered
+
+- Basic SSH connectivity and handshake
+- Password authentication (valid/invalid passwords)
+- Public key authentication (multiple key types: RSA, Ed25519, ECDSA)
+- Custom port configurations
+- Security hardening validation
+- Environment variable validation
+- Authentication method restrictions
+- Debug mode functionality
+
+## Development Best Practices
+
+- All SSH configuration happens at runtime through environment variables
+- The entrypoint script validates all environment variables
+  and provides sensible defaults
+- Container logs provide detailed debug information when SSH_DEBUG_LEVEL > 0
+- Test scripts support both individual testing and comprehensive test suites
+- Docker Compose provides multiple preconfigured scenarios for common use cases
+
+## Use Cases
+
+This SSH test server is ideal for:
+
+- Testing SSH clients and automation tools
+- WebSSH client development and testing
+- CI/CD pipeline SSH connectivity validation
+- SSH authentication method testing
+- Security configuration validation
+- Development environments requiring consistent SSH targets
+
+## Important Notes
+
+- Container is designed for testing environments, not production use
+- All test scripts require `sshpass` for password authentication testing
+- Integration tests automatically generate and cleanup temporary SSH keys
+- The entrypoint script provides comprehensive logging and error handling
+- Security scanning and SBOM generation are part of the CI/CD pipeline

--- a/KEYBOARD-INTERACTIVE.md
+++ b/KEYBOARD-INTERACTIVE.md
@@ -1,0 +1,154 @@
+Keyboard-Interactive Authentication – Options, Setup, and Plan
+
+Overview
+
+- Goal: Enable flexible keyboard-interactive (KI) authentication in the test containers for realistic client testing scenarios.
+- Images: Debian and Alpine variants are supported; Debian provides the easiest path to PAM-backed KI.
+- Current state: The images already support KI toggles via env and can run a PAM-backed password prompt as KI.
+
+What Works Today (no code changes required)
+
+- Enable KI: Set `SSH_CHALLENGE_RESPONSE_AUTH=yes`.
+- Use PAM on Debian: Set `SSH_USE_PAM=yes` (Debian only; Alpine variant currently ships without PAM).
+- Choose auth flows using `SSH_AUTH_METHODS`:
+  - Only KI (password-like prompt): `keyboard-interactive`
+  - 2-step with key then KI: `publickey,keyboard-interactive`
+  - 2-step with password then KI: `password,keyboard-interactive`
+- Example (Debian): use the user’s password as the KI response
+  - Env:
+    - `SSH_USER=kiuser`
+    - `SSH_PASSWORD=kipass` (sets the user’s password)
+    - `SSH_PERMIT_PASSWORD_AUTH=no` (prevent plain password method)
+    - `SSH_PERMIT_PUBKEY_AUTH=no`
+    - `SSH_CHALLENGE_RESPONSE_AUTH=yes`
+    - `SSH_USE_PAM=yes`
+    - `SSH_AUTH_METHODS=keyboard-interactive`
+  - Connect: `ssh -o PreferredAuthentications=keyboard-interactive -p 2229 kiuser@localhost` and respond with `kipass`.
+  - A ready-to-run profile exists under `examples/docker-compose.yml` → `ssh-keyboard-interactive`.
+
+Planned Additions
+
+1) Static OTP (fake second factor) assigned at runtime via ENV
+   - Objective: Simulate a 2FA prompt using KI, where the response is a container-provided “one-time” value set at start.
+   - Approach A (simple, no extra PAM modules): Reuse the account password as the OTP
+     - Set `SSH_PERMIT_PASSWORD_AUTH=no` to avoid plain password logins.
+     - Require a first factor plus KI: set `SSH_AUTH_METHODS=publickey,keyboard-interactive` (first factor = public key; second = KI where the response equals the user’s password, serving as the OTP).
+     - Add a new env alias for clarity (planned): `SSH_KI_STATIC_OTP`. If set, the entrypoint will set the user’s Linux password to this value solely for KI use. This keeps “OTP” separate from any documented user password used elsewhere.
+     - Pros: No new packages; works with existing OpenSSH + PAM on Debian.
+     - Cons: KI prompt label is generic ("Password:"); functionally valid but not a custom "Verification code:" prompt.
+
+   - Approach B (more realistic prompt/flow): Use a PAM module that prompts for a verification code
+     - Debian: Install `libpam-google-authenticator` (TOTP) or `libpam-oath` (HOTP/TOTP) and configure `/etc/pam.d/sshd` to require it after public key or password.
+     - Alpine: Install PAM-capable OpenSSH and modules (e.g., `openssh-server-pam`, `linux-pam`, plus the chosen PAM module), then enable `UsePAM yes`.
+     - Pros: Realistic second-factor prompt and flow. Matches client expectations for TOTP-like KI.
+     - Cons: Larger image and extra config. Requires changes to Dockerfiles and entrypoint.
+
+2) Other KI methods to consider
+   - TOTP: `libpam-google-authenticator` (user secret stored per-user, supports rate limiting and lockout).
+   - HOTP/TOTP via OATH Toolkit: `libpam-oath` with tokens configured in a file (can be container-initialized).
+   - RADIUS: `pam_radius_auth` to delegate to a test RADIUS server (can be another container).
+   - DUO: `pam_duo` for push/SMS/OTP simulation (requires external service or a mock).
+   - Policy and timing tests: `pam_time` (time-of-day), `pam_delay` (latency), `pam_faildelay` (throttling), `pam_permit` (always-pass) for client behavior testing.
+
+Configuration Matrix and Guidance
+
+- Debian (recommended for KI):
+  - Enable KI: `SSH_CHALLENGE_RESPONSE_AUTH=yes`
+  - Enable PAM: `SSH_USE_PAM=yes`
+  - Choose method combinations via `SSH_AUTH_METHODS`:
+    - `keyboard-interactive` (KI only)
+    - `publickey,keyboard-interactive` (key then KI)
+    - `password,keyboard-interactive` (password then KI)
+  - Static OTP (Approach A):
+    - Planned env: `SSH_KI_STATIC_OTP=123456`
+    - Set `SSH_PERMIT_PASSWORD_AUTH=no`
+    - Set `SSH_AUTH_METHODS=publickey,keyboard-interactive`
+    - Result: client authenticates by public key, then enters `123456` at the KI prompt.
+
+- Alpine (current image):
+  - OpenSSH installed without PAM; KI toggles exist, but PAM-backed flows and advanced prompts require a PAM-enabled build.
+  - Option 1: Keep simple KI tests on Debian; skip Alpine for KI second-factor scenarios.
+  - Option 2 (planned): Provide an Alpine-PAM variant by adding `openssh-server-pam` and `linux-pam`, enabling `UsePAM yes`, and wiring the same env/options.
+
+Examples
+
+- 2FA with public key + KI (static OTP) – Debian
+  - Intention: First factor = public key, second = KI response (static OTP).
+  - Env (planned):
+    - `SSH_USER=kiuser`
+    - `SSH_AUTHORIZED_KEYS=$(cat test_key.pub)`
+    - `SSH_PERMIT_PUBKEY_AUTH=yes`
+    - `SSH_PERMIT_PASSWORD_AUTH=no`
+    - `SSH_CHALLENGE_RESPONSE_AUTH=yes`
+    - `SSH_USE_PAM=yes`
+    - `SSH_AUTH_METHODS=publickey,keyboard-interactive`
+    - `SSH_KI_STATIC_OTP=123456`  # entrypoint sets user’s password to this OTP for KI only
+  - Client:
+    - `ssh -i test_key -o PreferredAuthentications=publickey,keyboard-interactive -p 2224 kiuser@localhost`
+    - Respond to KI with `123456`.
+
+- 2FA with password + KI (static OTP) – Debian
+  - Intention: First factor = password, second = KI response (static OTP). Useful to test multi-prompt flows.
+  - Env (planned):
+    - `SSH_USER=kiuser`
+    - `SSH_PASSWORD=firstfactor`
+    - `SSH_PERMIT_PASSWORD_AUTH=yes`
+    - `SSH_PERMIT_PUBKEY_AUTH=no`
+    - `SSH_CHALLENGE_RESPONSE_AUTH=yes`
+    - `SSH_USE_PAM=yes`
+    - `SSH_AUTH_METHODS=password,keyboard-interactive`
+    - `SSH_KI_STATIC_OTP=654321`
+  - Client:
+    - `ssh -o PreferredAuthentications=password,keyboard-interactive -p 2224 kiuser@localhost`
+    - Enter `firstfactor` then `654321` for KI.
+
+Validation Tips
+
+- Server-side: `docker logs -f <container>` with `SSH_DEBUG_LEVEL=2` or `3` to trace auth.
+- Client-side:
+  - Force KI path: `ssh -o PreferredAuthentications=keyboard-interactive ...`
+  - Require combos: `ssh -o PreferredAuthentications=publickey,keyboard-interactive ...`
+- Verify config in container: `docker exec <container> cat /etc/ssh/sshd_config`
+- Check PAM on Debian: `docker exec <container> cat /etc/pam.d/sshd`
+
+Implementation Plan (minimal changes)
+
+1) Add static OTP env handling (Debian first)
+   - New envs:
+     - `SSH_KI_STATIC_OTP` (string, optional)
+     - `SSH_KI_ENABLE` (bool, optional alias for `SSH_CHALLENGE_RESPONSE_AUTH`)
+   - EntryPoint changes:
+     - If `SSH_KI_STATIC_OTP` is set and `SSH_USE_PAM=yes`:
+       - Ensure `SSH_PERMIT_PASSWORD_AUTH=no` (documented or auto-enforced with a warning).
+       - Set the user’s password to `SSH_KI_STATIC_OTP` at startup strictly for KI use.
+       - Recommend `SSH_AUTH_METHODS=publickey,keyboard-interactive` or `password,keyboard-interactive`.
+     - Safety: Log clear warnings that this is a test-only OTP.
+
+2) Optional advanced KI via PAM modules
+   - Debian: Add optional install (build-arg or variant) for `libpam-google-authenticator` and/or `libpam-oath`.
+   - EntryPoint: When enabled via env, write `/etc/pam.d/sshd` stanzas to require the chosen module after first factor.
+   - Provide a helper script to pre-seed per-user secrets from env or mounted files.
+
+3) Alpine PAM support (optional variant)
+   - Create an Alpine-PAM image with `openssh-server-pam` and `linux-pam`.
+   - Mirror Debian behavior for KI, static OTP, and optional TOTP.
+
+Security and Caveats
+
+- Never expose containers publicly; these flows are for testing.
+- The static OTP is not secure; it is intentionally predictable for tests.
+- With approach A, the KI prompt label is generic; clients typically only need a prompt/response round, not a specific label.
+- When using real PAM modules, be aware of rate limits, lockouts, and secret storage.
+
+Open Questions
+
+- Do we prefer a dedicated Debian-only implementation first, or also ship an Alpine-PAM variant?
+- Should the static OTP be per-user configurable (multi-user container)?
+- Do we want a custom prompt message (e.g., "Verification code:")? That requires a PAM module that prompts.
+
+How to Proceed
+
+- If this plan looks good, I can:
+  1) Wire `SSH_KI_STATIC_OTP` into the entrypoint (Debian image),
+  2) Add an example Compose profile for key+KI(OTP) and password+KI(OTP), and
+  3) Extend integration tests to cover KI flows and the 2-step combos.

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ CONTAINER_NAME ?= ssh-test-dev
 SSH_PORT ?= 2224
 SSH_USER ?= testuser
 SSH_PASSWORD ?= testpass123
+TELNET_PORT ?= 2323
 
 # Build targets
 build: build-debian ## Build the default (Debian) Docker image
@@ -85,12 +86,22 @@ run-debug: ## Run container with debug mode enabled
 		-e SSH_DEBUG_LEVEL=3 \
 		$(IMAGE_NAME):$(IMAGE_TAG)
 
+run-telnet: ## Run Debian container with telnet enabled
+	docker run -d --name $(CONTAINER_NAME)-telnet \
+		-p $(SSH_PORT):22 \
+		-p $(TELNET_PORT):23 \
+		-e SSH_USER=$(SSH_USER) \
+		-e SSH_PASSWORD=$(SSH_PASSWORD) \
+		-e TELNET_ENABLED=yes \
+		-e SSH_DEBUG_LEVEL=1 \
+		$(IMAGE_NAME):debian
+
 stop: ## Stop all running containers
-	docker stop $(CONTAINER_NAME)-debian $(CONTAINER_NAME)-alpine $(CONTAINER_NAME)-dropbear || true
+	docker stop $(CONTAINER_NAME)-debian $(CONTAINER_NAME)-alpine $(CONTAINER_NAME)-dropbear $(CONTAINER_NAME)-telnet || true
 	docker stop $(CONTAINER_NAME) $(CONTAINER_NAME)-debug || true
 
 clean: ## Remove containers and images
-	docker rm -f $(CONTAINER_NAME)-debian $(CONTAINER_NAME)-alpine $(CONTAINER_NAME)-dropbear || true
+	docker rm -f $(CONTAINER_NAME)-debian $(CONTAINER_NAME)-alpine $(CONTAINER_NAME)-dropbear $(CONTAINER_NAME)-telnet || true
 	docker rm -f $(CONTAINER_NAME) $(CONTAINER_NAME)-debug || true
 	docker rmi $(IMAGE_NAME):debian $(IMAGE_NAME):alpine $(IMAGE_NAME):dropbear $(IMAGE_NAME):latest || true
 	docker rmi $(IMAGE_NAME):$(IMAGE_TAG) || true
@@ -154,6 +165,10 @@ test-auth-alpine: ## Test authentication methods on Alpine container
 
 test-auth-dropbear: ## Test authentication methods on Dropbear container
 	./scripts/test-auth-methods.sh --container $(CONTAINER_NAME)-dropbear --user $(SSH_USER) --generate-keys
+
+test-telnet: ## Quick telnet connection test
+	@echo "Testing telnet connectivity on port $(TELNET_PORT)..."
+	@echo "" | nc -w 3 localhost $(TELNET_PORT) && echo "✅ Telnet server is accessible" || echo "❌ Telnet server is not accessible"
 
 test-agent: test-agent-debian ## Run SSH agent tests on default (Debian) image
 
@@ -239,6 +254,9 @@ compose-agent-basic: ## Start basic SSH agent service
 
 compose-agent-keys: ## Start SSH agent service with preloaded keys
 	docker-compose --profile agent-keys up -d
+
+compose-telnet: ## Start telnet service via Docker Compose
+	docker-compose --profile telnet up -d
 
 # CI/CD simulation
 ci-build: ## Simulate CI build process

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 A fully configurable SSH server Docker container designed specifically for integration testing, development, and SSH client validation. Built with security best practices and complete runtime configurability.
 
 **Available in three optimized variants:**
+
 - **Debian-based** (`ghcr.io/billchurch/ssh_test:debian`): 118MB - Maximum compatibility with full GNU toolchain
 - **Alpine-based** (`ghcr.io/billchurch/ssh_test:alpine`): 13.8MB - Ultra-minimal footprint for resource-constrained environments
 - **Dropbear** (`ghcr.io/billchurch/ssh_test:dropbear`): ~5MB - BusyBox-style SSH with SCP but **no SFTP** ([webssh2 #483](https://github.com/billchurch/webssh2/issues/483))
@@ -20,6 +21,7 @@ A fully configurable SSH server Docker container designed specifically for integ
 - 🐛 **Debug Support**: Adjustable SSH debug levels with proper logging
 - 📊 **CI/CD Ready**: Automated builds, testing, and container registry publishing
 - 🧪 **Testing Tools**: Comprehensive test scripts and integration tests included
+- 📡 **Optional Telnet**: Built-in telnet server for terminal client testing (Debian only)
 
 ## Quick Start
 
@@ -90,6 +92,9 @@ docker-compose --profile all up -d
 
 # Run Dropbear version (SCP only, no SFTP)
 docker-compose --profile dropbear up -d
+
+# Telnet server (Debian with telnet enabled)
+docker-compose --profile telnet up -d
 
 # Traditional profiles still available
 docker-compose --profile basic up -d        # Basic password auth
@@ -180,7 +185,7 @@ All configuration is done through environment variables:
 ### Basic Configuration
 
 | Variable | Default | Description |
-|----------|---------|-------------|
+| --- | --- | --- |
 | `SSH_USER` | `testuser` | SSH username to create |
 | `SSH_PASSWORD` | *(empty)* | Password for the SSH user |
 | `SSH_PORT` | `22` | SSH server port |
@@ -189,7 +194,7 @@ All configuration is done through environment variables:
 ### Authentication Configuration
 
 | Variable | Default | Description |
-|----------|---------|-------------|
+| --- | --- | --- |
 | `SSH_PERMIT_PASSWORD_AUTH` | `yes` | Enable password authentication |
 | `SSH_PERMIT_PUBKEY_AUTH` | `yes` | Enable public key authentication |
 | `SSH_CHALLENGE_RESPONSE_AUTH` | `no` | Enable keyboard-interactive auth |
@@ -199,7 +204,7 @@ All configuration is done through environment variables:
 ### Security Configuration
 
 | Variable | Default | Description |
-|----------|---------|-------------|
+| --- | --- | --- |
 | `SSH_PERMIT_ROOT_LOGIN` | `no` | Allow root login |
 | `SSH_PERMIT_EMPTY_PASSWORDS` | `no` | Allow empty passwords |
 | `SSH_MAX_AUTH_TRIES` | `6` | Maximum authentication attempts |
@@ -209,17 +214,28 @@ All configuration is done through environment variables:
 ### Forwarding Configuration
 
 | Variable | Default | Description |
-|----------|---------|-------------|
+| --- | --- | --- |
 | `SSH_X11_FORWARDING` | `no` | Enable X11 forwarding |
 | `SSH_AGENT_FORWARDING` | `no` | Enable SSH agent forwarding |
 | `SSH_TCP_FORWARDING` | `no` | Enable TCP forwarding |
+
+### Telnet Configuration (Debian Only)
+
+The Debian image includes an optional telnet server for testing terminal clients against a plaintext protocol. Disabled by default.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `TELNET_ENABLED` | `no` | Enable telnet server (`yes`/`no`) |
+| `TELNET_PORT` | `23` | Telnet server port |
+
+Authentication reuses `SSH_USER` and `SSH_PASSWORD` — telnet spawns `/bin/login` which authenticates against the system user.
 
 ### SSH Agent Configuration
 
 The SSH test server includes comprehensive SSH agent support for testing agent-based authentication and forwarding scenarios.
 
 | Variable | Default | Description |
-|----------|---------|-------------|
+| --- | --- | --- |
 | `SSH_AGENT_START` | `no` | Start internal SSH agent in container |
 | `SSH_AGENT_KEYS` | *(empty)* | Base64-encoded private keys to load into agent (newline-separated) |
 | `SSH_AGENT_SOCKET_PATH` | `/tmp/ssh-agent.sock` | Custom path for SSH agent socket |
@@ -244,7 +260,7 @@ The SSH test server includes comprehensive SSH agent support for testing agent-b
 ### Advanced Configuration
 
 | Variable | Default | Description |
-|----------|---------|-------------|
+| --- | --- | --- |
 | `SSH_HOST_KEYS` | *(auto-generated)* | Custom host keys (base64 encoded) |
 | `SSH_CUSTOM_CONFIG` | *(empty)* | Additional sshd_config directives |
 | `SSH_USE_PAM` | `no` | Use PAM for authentication |
@@ -394,6 +410,35 @@ docker run -d --name ssh-forwarding-test \
 ssh -A -p 2224 forwarduser@localhost
 ```
 
+### Telnet Server (Debian Only)
+
+```bash
+# Run Debian image with telnet enabled
+docker run -d --name ssh-telnet-test \
+  -p 2224:22 \
+  -p 2323:23 \
+  -e SSH_USER=testuser \
+  -e SSH_PASSWORD=testpass123 \
+  -e TELNET_ENABLED=yes \
+  ghcr.io/billchurch/ssh_test:debian
+
+# Connect via telnet
+telnet localhost 2323
+
+# SSH still works alongside telnet
+ssh -p 2224 testuser@localhost
+
+# Custom telnet port
+docker run -d --name ssh-telnet-custom \
+  -p 2224:22 \
+  -p 8023:8023 \
+  -e SSH_USER=testuser \
+  -e SSH_PASSWORD=testpass123 \
+  -e TELNET_ENABLED=yes \
+  -e TELNET_PORT=8023 \
+  ghcr.io/billchurch/ssh_test:debian
+```
+
 ## Testing Tools
 
 The project includes comprehensive testing tools:
@@ -485,6 +530,7 @@ make integration-test        # Build both + test both
 We welcome contributions! This project uses automated releases and conventional commit messages.
 
 **Quick Start:**
+
 1. Fork the repository
 2. Create a feature branch: `git checkout -b feature/your-feature`
 3. Make changes following our [contribution guidelines](CONTRIBUTING.md)
@@ -493,6 +539,7 @@ We welcome contributions! This project uses automated releases and conventional 
 6. Submit a pull request
 
 **Important:** Please read our [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines on:
+
 - Conventional commit message format
 - Development workflow
 - Testing requirements  
@@ -586,6 +633,7 @@ docker run -d --name dev-ssh \
 ### Common Issues
 
 **Container fails to start:**
+
 ```bash
 # Check container logs
 docker logs container-name
@@ -595,6 +643,7 @@ docker inspect container-name | jq '.Config.Env'
 ```
 
 **SSH connection refused:**
+
 ```bash
 # Test port connectivity
 nc -zv localhost 2224
@@ -604,6 +653,7 @@ docker exec container-name ps aux | grep sshd
 ```
 
 **Authentication failures:**
+
 ```bash
 # Enable debug mode
 docker run ... -e SSH_DEBUG_LEVEL=3 ...
@@ -623,6 +673,7 @@ When using public key authentication without setting a password (SSH_PASSWORD no
    - Still prevents password-based login (no valid password can match `*`)
 
 If you experience issues with key authentication:
+
 ```bash
 # Check if user account is locked
 docker exec container-name grep username /etc/shadow
@@ -635,7 +686,7 @@ docker exec container-name usermod -p '*' username
 docker exec container-name cat /home/username/.ssh/authorized_keys
 ```
 
-### Debug Mode
+### Enabling Debug Mode
 
 Enable maximum debug output:
 
@@ -665,29 +716,34 @@ While designed for testing, security best practices are followed:
 
 ## Choosing Your Variant
 
-### Use Dropbear When:
+### Use Dropbear When
+
 - **Testing SCP fallback**: Your application needs to handle devices without SFTP
 - **BusyBox simulation**: Mimicking embedded/IoT devices that only support SSH + SCP
 - **webssh2 File Browser**: Testing the SCP fallback for [webssh2 #483](https://github.com/billchurch/webssh2/issues/483)
 - **Smallest footprint**: ~5MB image with just SSH and SCP
 
-### Use Alpine When:
+### Use Alpine When
+
 - **Size matters**: Ultra-minimal 13.8MB footprint
 - **Resource-constrained environments**: Kubernetes pods, edge computing
 - **Fast deployment**: Quicker download and startup times
 - **Security**: Smaller attack surface with minimal components
 - **Simple SSH testing**: Basic SSH client validation
 
-### Use Debian When:
-- **Maximum compatibility**: Full GNU toolchain and libraries  
+### Use Debian When
+
+- **Maximum compatibility**: Full GNU toolchain and libraries
 - **Complex applications**: Applications requiring specific libraries
 - **Legacy systems**: Compatibility with older SSH clients
 - **Development**: More debugging tools and utilities available
 - **Production-like testing**: Closer to typical server environments
+- **Telnet testing**: Optional telnet server for terminal client testing
 
-### Performance Comparison:
+### Performance Comparison
+
 | Metric | Dropbear | Alpine | Debian |
-|--------|----------|--------|--------|
+| --- | --- | --- | --- |
 | **Image Size** | ~5MB | 13.8MB | 118MB |
 | **Download Time** | ~1 second | ~2 seconds | ~15 seconds |
 | **Memory Usage** | ~4MB | ~8MB | ~20MB |
@@ -695,6 +751,7 @@ While designed for testing, security best practices are followed:
 | **SSH** | Yes | Yes | Yes |
 | **SCP** | Yes | Yes | Yes |
 | **SFTP** | **No** | Yes | Yes |
+| **Telnet** | **No** | **No** | Optional |
 | **Compatibility** | Limited | Good | Excellent |
 
 ## License

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && \
         mc \
         ncurses-bin \
         socat \
-        busybox \
+        busybox-static \
         libpam-google-authenticator \
         && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,6 +28,8 @@ RUN apt-get update && \
         mc \
         ncurses-bin \
         socat \
+        busybox \
+        libpam-google-authenticator \
         && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
               /usr/share/doc/* \
@@ -67,10 +69,16 @@ ENV SSH_USER=testuser \
     SSH_AGENT_START=no \
     SSH_AGENT_KEYS="" \
     SSH_AGENT_SOCKET_PATH="/tmp/ssh-agent.sock" \
-    SSH_CUSTOM_CONFIG=""
+    SSH_CUSTOM_CONFIG="" \
+    SSH_KI_STATIC_OTP="" \
+    TELNET_ENABLED=no \
+    TELNET_PORT=23
 
 # Expose SSH port (default 22, configurable via SSH_PORT)
 EXPOSE 22
+
+# Expose telnet port (default 23, configurable via TELNET_PORT)
+EXPOSE 23
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && \
         mc \
         ncurses-bin \
         socat \
-        busybox-static \
+        inetutils-telnetd \
         libpam-google-authenticator \
         && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -512,16 +512,19 @@ start_telnet() {
 
     log_info "Starting telnet server on port ${TELNET_PORT}..."
 
-    # Verify busybox telnetd is available
-    if ! command -v busybox >/dev/null 2>&1; then
-        log_error "busybox not found - telnet requires busybox"
+    # Verify inetutils-telnetd is available
+    if ! command -v telnetd >/dev/null 2>&1; then
+        log_error "telnetd not found - telnet requires inetutils-telnetd"
         return 1
     fi
 
-    # -F: foreground (we background it ourselves)
-    # -p: port to listen on
-    # -l: login program to spawn
-    busybox telnetd -F -p "${TELNET_PORT}" -l /bin/login &
+    # Use socat to listen and spawn telnetd for each connection.
+    # The nofork option passes the accepted socket directly to telnetd
+    # on stdin/stdout (as a real socket, not pipes), which telnetd
+    # requires for getpeername() to resolve the client address.
+    # telnetd handles telnet protocol negotiation including
+    # TERMINAL-TYPE (RFC 1091).
+    socat TCP-LISTEN:"${TELNET_PORT}",fork,reuseaddr EXEC:/usr/sbin/telnetd,nofork &
     TELNETD_PID=$!
     log_info "Telnet server started (PID ${TELNETD_PID})"
 }

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -69,7 +69,17 @@ validate_env() {
         log_warn "Invalid SSH_LOGIN_GRACE_TIME '${SSH_LOGIN_GRACE_TIME}', using default 120"
         export SSH_LOGIN_GRACE_TIME=120
     fi
-    
+
+    # Validate TELNET_PORT (only if telnet is enabled)
+    if [[ "${TELNET_ENABLED}" == "yes" ]]; then
+        if [[ ! "${TELNET_PORT}" =~ ^[0-9]+$ ]] \
+            || [[ "${TELNET_PORT}" -lt 1 ]] \
+            || [[ "${TELNET_PORT}" -gt 65535 ]]; then
+            log_warn "Invalid TELNET_PORT '${TELNET_PORT}', using default 23"
+            export TELNET_PORT=23
+        fi
+    fi
+
     # Validate SSH_USER
     if [[ -z "${SSH_USER}" ]]; then
         log_error "SSH_USER cannot be empty"
@@ -388,6 +398,60 @@ load_agent_keys() {
     log_info "SSH agent key loading completed"
 }
 
+# Setup static OTP for keyboard-interactive authentication
+setup_static_otp() {
+    if [[ -z "${SSH_KI_STATIC_OTP}" ]]; then
+        log_debug "No static OTP configured"
+        return 0
+    fi
+
+    if [ "$IS_ALPINE" = true ]; then
+        log_warn "SSH_KI_STATIC_OTP is not supported on Alpine (no PAM). Use Debian image."
+        return 0
+    fi
+
+    log_info "Configuring static OTP for keyboard-interactive authentication..."
+
+    # Create google-authenticator config for the user
+    local ga_file="/home/${SSH_USER}/.google_authenticator"
+
+    # For testing: use multiple identical scratch codes so the OTP can be reused
+    # We add many copies of the same code since each use consumes one
+    {
+        echo "AAAAAAAAAAAAAAAA"
+        echo "\" RATE_LIMIT 3 30"
+        echo "\" TOTP_AUTH"
+        # Add 100 copies of the scratch code for repeated testing
+        for _ in {1..100}; do
+            echo "${SSH_KI_STATIC_OTP}"
+        done
+    } > "${ga_file}"
+
+    chmod 600 "${ga_file}"
+    chown "${SSH_USER}:${SSH_USER}" "${ga_file}"
+
+    # Configure PAM for keyboard-interactive with google-authenticator
+    cp /etc/pam.d/sshd /etc/pam.d/sshd.orig
+
+    cat > /etc/pam.d/sshd << 'PAMCONFIG'
+# PAM configuration for SSH with two-factor authentication
+# First factor: password, Second factor: OTP via google-authenticator
+
+# Account and session handling
+@include common-account
+@include common-session
+
+# Authentication - Two factors:
+# Factor 1: Password check via pam_unix
+auth required pam_unix.so
+# Factor 2: OTP check via google-authenticator
+auth required pam_google_authenticator.so nullok
+PAMCONFIG
+
+    log_info "Static OTP configured (OTP: ${SSH_KI_STATIC_OTP})"
+    log_debug "PAM configured with google-authenticator for KI auth"
+}
+
 # Setup agent forwarding environment
 setup_agent_forwarding() {
     log_debug "Setting up SSH agent forwarding environment..."
@@ -439,6 +503,29 @@ EOF
     log_debug "Agent forwarding setup completed"
 }
 
+# Start telnet server if enabled
+start_telnet() {
+    if [[ "${TELNET_ENABLED}" != "yes" ]]; then
+        log_debug "Telnet server disabled"
+        return 0
+    fi
+
+    log_info "Starting telnet server on port ${TELNET_PORT}..."
+
+    # Verify busybox telnetd is available
+    if ! command -v busybox >/dev/null 2>&1; then
+        log_error "busybox not found - telnet requires busybox"
+        return 1
+    fi
+
+    # -F: foreground (we background it ourselves)
+    # -p: port to listen on
+    # -l: login program to spawn
+    busybox telnetd -F -p "${TELNET_PORT}" -l /bin/login &
+    TELNETD_PID=$!
+    log_info "Telnet server started (PID ${TELNETD_PID})"
+}
+
 # Print startup information
 print_startup_info() {
     echo ""
@@ -470,7 +557,13 @@ print_startup_info() {
     else
         log_info "SSH Agent: Disabled"
     fi
-    
+
+    if [[ "${TELNET_ENABLED}" == "yes" ]]; then
+        log_info "Telnet: Enabled (port ${TELNET_PORT})"
+    else
+        log_info "Telnet: Disabled"
+    fi
+
     log_info "=========================="
     
     # Display MOTD for direct exec sessions
@@ -499,13 +592,19 @@ main() {
     
     # Start SSH agent if requested
     start_ssh_agent
-    
+
     # Setup agent forwarding environment
     setup_agent_forwarding
-    
+
+    # Setup static OTP for keyboard-interactive if configured
+    setup_static_otp
+
     # Configure SSH daemon
     configure_sshd
-    
+
+    # Start telnet server if enabled
+    start_telnet
+
     # Print startup information
     print_startup_info
     
@@ -543,8 +642,13 @@ main() {
     SSHD_PID=$!
     log_debug "sshd started with PID ${SSHD_PID}"
     
-    # Attach to sshd process and wait; traps will handle termination.
-    wait "${SSHD_PID}"
+    # Wait for background processes; traps will handle termination.
+    # If telnet is running, wait for either process to exit.
+    if [[ -n "${TELNETD_PID}" ]]; then
+        wait -n "${SSHD_PID}" "${TELNETD_PID}"
+    else
+        wait "${SSHD_PID}"
+    fi
 }
 
 # Cleanup function
@@ -570,7 +674,15 @@ cleanup() {
         rm -f "${SSH_AGENT_SOCKET_PATH}"
         log_info "SSH agent stopped"
     fi
-    
+
+    # Stop telnet server if it's running
+    if [[ -n "${TELNETD_PID}" ]] \
+        && kill -0 "${TELNETD_PID}" >/dev/null 2>&1; then
+        log_debug "Stopping telnet server (PID ${TELNETD_PID})..."
+        kill -TERM "${TELNETD_PID}" >/dev/null 2>&1 || true
+        log_info "Telnet server stopped"
+    fi
+
     exit 0
 }
 

--- a/docs/plans/2026-02-26-telnet-server-design.md
+++ b/docs/plans/2026-02-26-telnet-server-design.md
@@ -1,0 +1,82 @@
+# Telnet Server Design
+
+## Purpose
+
+Add an optional telnet server to the Debian image for testing web-based
+terminal clients (e.g., webssh2) against a plaintext telnet target. The telnet
+server is disabled by default and enabled via environment variable, following
+the existing pattern used by `SSH_AGENT_START`.
+
+## Scope
+
+- Debian image only (Alpine and Dropbear variants are not affected)
+- Opt-in via `TELNET_ENABLED=yes` (default: `no`)
+- Reuses existing `SSH_USER` / `SSH_PASSWORD` for authentication
+
+## Environment Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `TELNET_ENABLED` | `no` | Enable/disable telnet server |
+| `TELNET_PORT` | `23` | Port for telnet to listen on |
+
+No new authentication variables. Telnet spawns `/bin/login` which
+authenticates against the system user created by `create_ssh_user()`.
+
+## Architecture
+
+### Daemon
+
+Uses `busybox telnetd` which provides proper telnet protocol negotiation
+(option handling, terminal type, window size) while remaining lightweight
+(~500KB package). The applet runs in the foreground via `-F` flag, backgrounded
+by the entrypoint script alongside sshd.
+
+### Process Model
+
+```text
+entrypoint.sh (PID 1)
+  ├── /usr/sbin/sshd -D -e  (background, always)
+  └── busybox telnetd -F     (background, when TELNET_ENABLED=yes)
+```
+
+Both child processes are tracked by PID and cleaned up in the `cleanup()`
+signal handler on container shutdown.
+
+## Files Changed
+
+### `docker/Dockerfile`
+
+- Add `busybox` to `apt-get install` line
+- Add `TELNET_ENABLED=no` and `TELNET_PORT=23` to ENV block
+- Add `EXPOSE 23`
+
+### `docker/entrypoint.sh`
+
+- Add `TELNET_PORT` validation in `validate_env()`
+- Add `start_telnet()` function called from `main()` after `configure_sshd()`
+- Update `print_startup_info()` to show telnet status
+- Update `cleanup()` to kill telnetd process
+
+### `examples/docker-compose.yml`
+
+- Add `ssh-telnet` service with `telnet` profile
+
+### `Makefile`
+
+- Add `run-telnet` target
+- Add `test-telnet` target (placeholder or wired to integration tests)
+
+## Testing
+
+- Telnet connectivity: connect to port, receive login prompt
+- Successful login with correct credentials
+- Failed login with wrong credentials
+- Telnet disabled by default (port not listening)
+- Custom port via `TELNET_PORT`
+- Container shutdown cleanly terminates telnetd
+
+## Backward Compatibility
+
+Zero impact on existing users. `TELNET_ENABLED` defaults to `no`, so the image
+behaves identically to the current release unless the user explicitly opts in.

--- a/docs/plans/2026-02-26-telnet-server-plan.md
+++ b/docs/plans/2026-02-26-telnet-server-plan.md
@@ -1,0 +1,542 @@
+# Telnet Server Implementation Plan
+
+<!-- markdownlint-disable MD001 MD013 MD024 -->
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans
+> to implement this plan task-by-task.
+
+<!-- markdownlint-enable MD013 -->
+
+**Goal:** Add an optional busybox telnetd to the Debian image,
+enabled via `TELNET_ENABLED=yes`, for webssh2 terminal client
+testing.
+
+**Architecture:** The telnet daemon runs as a second background
+process alongside sshd, managed by the existing entrypoint script.
+It uses busybox telnetd with `/bin/login` for authentication,
+reusing the system user created by `create_ssh_user()`. Disabled
+by default; zero behavioral change for existing users.
+
+**Tech Stack:** busybox telnetd, bash, Docker, Make
+
+---
+
+## Task 1: Add busybox package to Dockerfile
+
+**Files:**
+
+- Modify: `docker/Dockerfile:23-39` (apt-get install block)
+
+#### Step 1: Add busybox to the install list
+
+In `docker/Dockerfile`, add `busybox` after the `socat` line
+(line 30):
+
+```dockerfile
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        openssh-server \
+        openssh-client \
+        bash \
+        mc \
+        ncurses-bin \
+        socat \
+        busybox \
+        libpam-google-authenticator \
+        && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+              /usr/share/doc/* \
+              /usr/share/man/* \
+              /usr/share/locale/* \
+              /tmp/* \
+              /var/tmp/* \
+    && mkdir -p /var/run/sshd /etc/ssh/ssh_host_keys
+```
+
+#### Step 2: Verify the edit
+
+Run: `grep -n busybox docker/Dockerfile`
+Expected: Shows busybox on a line in the apt-get install block.
+
+#### Step 3: Commit
+
+```bash
+git add docker/Dockerfile
+git commit -m "feat: add busybox package for telnetd support"
+```
+
+---
+
+## Task 2: Add telnet ENV vars and EXPOSE to Dockerfile
+
+**Files:**
+
+- Modify: `docker/Dockerfile:46-75` (ENV block and EXPOSE)
+
+#### Step 1: Add TELNET env vars to the ENV block
+
+After the `SSH_KI_STATIC_OTP=""` line (line 72), add the telnet
+variables:
+
+```dockerfile
+ENV SSH_USER=testuser \
+    SSH_PASSWORD="" \
+    SSH_AUTHORIZED_KEYS="" \
+    SSH_HOST_KEYS="" \
+    SSH_PERMIT_PASSWORD_AUTH=yes \
+    SSH_PERMIT_ROOT_LOGIN=no \
+    SSH_PERMIT_EMPTY_PASSWORDS=no \
+    SSH_PORT=22 \
+    SSH_DEBUG_LEVEL=0 \
+    SSH_AUTH_METHODS="any" \
+    SSH_MAX_AUTH_TRIES=6 \
+    SSH_LOGIN_GRACE_TIME=120 \
+    SSH_PERMIT_PUBKEY_AUTH=yes \
+    SSH_CHALLENGE_RESPONSE_AUTH=no \
+    SSH_USE_PAM=no \
+    SSH_USE_DNS=no \
+    SSH_X11_FORWARDING=no \
+    SSH_AGENT_FORWARDING=no \
+    SSH_TCP_FORWARDING=no \
+    SSH_AGENT_START=no \
+    SSH_AGENT_KEYS="" \
+    SSH_AGENT_SOCKET_PATH="/tmp/ssh-agent.sock" \
+    SSH_CUSTOM_CONFIG="" \
+    SSH_KI_STATIC_OTP="" \
+    TELNET_ENABLED=no \
+    TELNET_PORT=23
+```
+
+#### Step 2: Add EXPOSE 23
+
+After the existing `EXPOSE 22` line (line 75), add:
+
+```dockerfile
+# Expose SSH port (default 22, configurable via SSH_PORT)
+EXPOSE 22
+
+# Expose telnet port (default 23, configurable via TELNET_PORT)
+EXPOSE 23
+```
+
+#### Step 3: Verify
+
+Run: `grep -n -E 'TELNET|EXPOSE' docker/Dockerfile`
+Expected: Shows TELNET_ENABLED, TELNET_PORT in ENV block and
+both EXPOSE lines.
+
+#### Step 4: Commit
+
+```bash
+git add docker/Dockerfile
+git commit -m "feat: add TELNET env vars and EXPOSE to Dockerfile"
+```
+
+---
+
+## Task 3: Add TELNET_PORT validation to entrypoint
+
+**Files:**
+
+- Modify: `docker/entrypoint.sh:46-88` (validate_env function)
+
+#### Step 1: Add TELNET_PORT validation
+
+After the `SSH_LOGIN_GRACE_TIME` validation block (line 71) and
+before the `SSH_USER` validation (line 73), add:
+
+```bash
+    # Validate TELNET_PORT (only if telnet is enabled)
+    if [[ "${TELNET_ENABLED}" == "yes" ]]; then
+        if [[ ! "${TELNET_PORT}" =~ ^[0-9]+$ ]] \
+            || [[ "${TELNET_PORT}" -lt 1 ]] \
+            || [[ "${TELNET_PORT}" -gt 65535 ]]; then
+            log_warn "Invalid TELNET_PORT '${TELNET_PORT}', using default 23"
+            export TELNET_PORT=23
+        fi
+    fi
+```
+
+#### Step 2: Verify
+
+Run: `grep -n TELNET docker/entrypoint.sh`
+Expected: Shows the TELNET_PORT validation lines in
+validate_env.
+
+#### Step 3: Commit
+
+```bash
+git add docker/entrypoint.sh
+git commit -m "feat: add TELNET_PORT validation to entrypoint"
+```
+
+---
+
+## Task 4: Add start_telnet() function to entrypoint
+
+**Files:**
+
+- Modify: `docker/entrypoint.sh` (add function + call in main)
+
+#### Step 1: Add the start_telnet function
+
+Insert before the `print_startup_info()` function (before
+line 497):
+
+```bash
+# Start telnet server if enabled
+start_telnet() {
+    if [[ "${TELNET_ENABLED}" != "yes" ]]; then
+        log_debug "Telnet server disabled"
+        return 0
+    fi
+
+    log_info "Starting telnet server on port ${TELNET_PORT}..."
+
+    # Verify busybox telnetd is available
+    if ! command -v busybox >/dev/null 2>&1; then
+        log_error "busybox not found - telnet requires busybox"
+        return 1
+    fi
+
+    # -F: foreground (we background it ourselves)
+    # -p: port to listen on
+    # -l: login program to spawn
+    busybox telnetd -F -p "${TELNET_PORT}" -l /bin/login &
+    TELNETD_PID=$!
+    log_info "Telnet server started (PID ${TELNETD_PID})"
+}
+```
+
+#### Step 2: Call start_telnet from main()
+
+In `main()`, after `configure_sshd` (line 564) and before
+`print_startup_info` (line 567), add:
+
+```bash
+    # Start telnet server if enabled
+    start_telnet
+```
+
+#### Step 3: Verify
+
+Run: `grep -n -A2 'start_telnet\|telnet' docker/entrypoint.sh`
+Expected: Shows the function definition and the call in main().
+
+#### Step 4: Commit
+
+```bash
+git add docker/entrypoint.sh
+git commit -m "feat: add start_telnet() function to entrypoint"
+```
+
+---
+
+## Task 5: Update print_startup_info() for telnet
+
+**Files:**
+
+- Modify: `docker/entrypoint.sh` (print_startup_info function)
+
+#### Step 1: Add telnet status to startup info
+
+After the SSH Agent block (before the `==` separator line),
+add:
+
+```bash
+    if [[ "${TELNET_ENABLED}" == "yes" ]]; then
+        log_info "Telnet: Enabled (port ${TELNET_PORT})"
+    else
+        log_info "Telnet: Disabled"
+    fi
+```
+
+#### Step 2: Verify
+
+Run: `grep -n -B1 -A3 'Telnet' docker/entrypoint.sh`
+Expected: Shows the telnet status block in print_startup_info.
+
+#### Step 3: Commit
+
+```bash
+git add docker/entrypoint.sh
+git commit -m "feat: show telnet status in startup info"
+```
+
+---
+
+## Task 6: Update cleanup() to stop telnetd
+
+**Files:**
+
+- Modify: `docker/entrypoint.sh` (cleanup function + main wait)
+
+#### Step 1: Add telnetd cleanup
+
+After the SSH agent cleanup block and before `exit 0`, add:
+
+```bash
+    # Stop telnet server if it's running
+    if [[ -n "${TELNETD_PID}" ]] \
+        && kill -0 "${TELNETD_PID}" >/dev/null 2>&1; then
+        log_debug "Stopping telnet server (PID ${TELNETD_PID})..."
+        kill -TERM "${TELNETD_PID}" >/dev/null 2>&1 || true
+        log_info "Telnet server stopped"
+    fi
+```
+
+#### Step 2: Update the wait in main()
+
+The current `main()` ends with `wait "${SSHD_PID}"`. Since we
+now have two background processes, change the end of main() to
+wait for both. Replace:
+
+```bash
+    # Attach to sshd process and wait
+    wait "${SSHD_PID}"
+```
+
+With:
+
+```bash
+    # Wait for background processes
+    if [[ -n "${TELNETD_PID}" ]]; then
+        wait -n "${SSHD_PID}" "${TELNETD_PID}"
+    else
+        wait "${SSHD_PID}"
+    fi
+```
+
+#### Step 3: Verify
+
+Run: `grep -n -B1 -A4 'TELNETD_PID' docker/entrypoint.sh`
+Expected: Shows TELNETD_PID in start_telnet, cleanup, and
+main wait.
+
+#### Step 4: Commit
+
+```bash
+git add docker/entrypoint.sh
+git commit -m "feat: add telnetd cleanup and multi-process wait"
+```
+
+---
+
+## Task 7: Add docker-compose telnet service
+
+**Files:**
+
+- Modify: `examples/docker-compose.yml` (add service)
+
+#### Step 1: Add telnet service
+
+Before the `volumes:` block (line 321), add:
+
+```yaml
+  # Telnet server for terminal client testing (webssh2)
+  ssh-telnet:
+    image: ghcr.io/billchurch/ssh_test:debian
+    container_name: ssh-test-telnet
+    ports:
+      - "2237:22"
+      - "2323:23"
+    environment:
+      - SSH_USER=testuser
+      - SSH_PASSWORD=testpass123
+      - SSH_PERMIT_PASSWORD_AUTH=yes
+      - TELNET_ENABLED=yes
+      - TELNET_PORT=23
+      - SSH_DEBUG_LEVEL=1
+    restart: unless-stopped
+    profiles:
+      - telnet
+      - all
+```
+
+#### Step 2: Verify
+
+Run: `grep -n -A15 'ssh-telnet' examples/docker-compose.yml`
+Expected: Shows the telnet service definition.
+
+#### Step 3: Commit
+
+```bash
+git add examples/docker-compose.yml
+git commit -m "feat: add telnet service to docker-compose"
+```
+
+---
+
+## Task 8: Add Makefile telnet targets
+
+**Files:**
+
+- Modify: `Makefile`
+
+#### Step 1: Add TELNET_PORT variable
+
+After the `SSH_PASSWORD` variable (line 19), add:
+
+```makefile
+TELNET_PORT ?= 2323
+```
+
+#### Step 2: Add run-telnet target
+
+After the `run-debug` target (after line 86), add:
+
+<!-- markdownlint-disable MD013 -->
+
+```makefile
+run-telnet: ## Run Debian container with telnet enabled
+ docker run -d --name $(CONTAINER_NAME)-telnet \
+  -p $(SSH_PORT):22 \
+  -p $(TELNET_PORT):23 \
+  -e SSH_USER=$(SSH_USER) \
+  -e SSH_PASSWORD=$(SSH_PASSWORD) \
+  -e TELNET_ENABLED=yes \
+  -e SSH_DEBUG_LEVEL=1 \
+  $(IMAGE_NAME):debian
+```
+
+<!-- markdownlint-enable MD013 -->
+
+#### Step 3: Add telnet container to stop and clean targets
+
+Update `stop` target to include the telnet container:
+
+<!-- markdownlint-disable MD013 -->
+
+```makefile
+stop: ## Stop all running containers
+ docker stop $(CONTAINER_NAME)-debian $(CONTAINER_NAME)-alpine $(CONTAINER_NAME)-dropbear $(CONTAINER_NAME)-telnet || true
+ docker stop $(CONTAINER_NAME) $(CONTAINER_NAME)-debug || true
+```
+
+Update `clean` target similarly:
+
+```makefile
+clean: ## Remove containers and images
+ docker rm -f $(CONTAINER_NAME)-debian $(CONTAINER_NAME)-alpine $(CONTAINER_NAME)-dropbear $(CONTAINER_NAME)-telnet || true
+ docker rm -f $(CONTAINER_NAME) $(CONTAINER_NAME)-debug || true
+ docker rmi $(IMAGE_NAME):debian $(IMAGE_NAME):alpine $(IMAGE_NAME):dropbear $(IMAGE_NAME):latest || true
+ docker rmi $(IMAGE_NAME):$(IMAGE_TAG) || true
+```
+
+<!-- markdownlint-enable MD013 -->
+
+#### Step 4: Add telnet-test target
+
+After the `test-auth-dropbear` target (after line 156), add:
+
+<!-- markdownlint-disable MD013 -->
+
+```makefile
+test-telnet: ## Quick telnet connection test
+ @echo "Testing telnet connectivity on port $(TELNET_PORT)..."
+ @echo "" | nc -w 3 localhost $(TELNET_PORT) && echo "✅ Telnet server is accessible" || echo "❌ Telnet server is not accessible"
+```
+
+<!-- markdownlint-enable MD013 -->
+
+#### Step 5: Add compose-telnet target
+
+After the `compose-agent-keys` target (after line 241), add:
+
+```makefile
+compose-telnet: ## Start telnet service via Docker Compose
+ docker-compose --profile telnet up -d
+```
+
+#### Step 6: Verify
+
+Run: `grep -n 'telnet\|TELNET' Makefile`
+Expected: Shows TELNET_PORT variable, run-telnet,
+test-telnet, compose-telnet targets.
+
+#### Step 7: Commit
+
+```bash
+git add Makefile
+git commit -m "feat: add telnet targets to Makefile"
+```
+
+---
+
+## Task 9: Build and manually test
+
+#### Step 1: Build the Debian image
+
+Run: `make build-debian`
+Expected: Image builds successfully with busybox package.
+
+#### Step 2: Run container with telnet enabled
+
+Run: `make run-telnet`
+Expected: Container starts, logs show
+"Telnet: Enabled (port 23)".
+
+#### Step 3: Verify telnet connectivity
+
+Run: `echo "" | nc -w 3 localhost 2323`
+Expected: Receives telnet protocol data (login prompt bytes).
+
+#### Step 4: Verify SSH still works
+
+Run: `make test-connection-debian` (adjust port if needed)
+Expected: SSH connection succeeds as before.
+
+#### Step 5: Verify telnet is disabled by default
+
+Run: `make run-debian` (without TELNET_ENABLED)
+Then: `nc -z localhost 23` should fail (port not listening).
+
+#### Step 6: Clean up
+
+Run: `make stop && make clean`
+
+#### Step 7: Commit if fixes were needed
+
+If fixes were required, commit with an appropriate message.
+
+---
+
+## Task 10: Update CLAUDE.md with telnet configuration
+
+**Files:**
+
+- Modify: `CLAUDE.md`
+
+#### Step 1: Add telnet configuration section
+
+In the "Configuration System" section of CLAUDE.md, after the
+"Network and Debug" subsection, add a "Telnet" subsection:
+
+```markdown
+### Telnet Configuration
+- `TELNET_ENABLED`: Enable telnet server (yes/no, default: no)
+- `TELNET_PORT`: Telnet server port (default: 23)
+```
+
+#### Step 2: Add telnet run example
+
+In the "Building and Running" section, add:
+
+<!-- markdownlint-disable MD013 -->
+
+```bash
+# Run with telnet enabled
+make run-telnet
+# Or: docker run -d --name ssh-test-dev -p 2222:22 -p 2323:23 \
+#   -e SSH_USER=testuser -e SSH_PASSWORD=testpass123 \
+#   -e TELNET_ENABLED=yes ssh-test-server:debian
+```
+
+<!-- markdownlint-enable MD013 -->
+
+#### Step 3: Commit
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add telnet configuration to CLAUDE.md"
+```

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -318,6 +318,25 @@ services:
       - agent-forwarding
       - ssh-agent
 
+  # Telnet server for terminal client testing (webssh2)
+  ssh-telnet:
+    image: ghcr.io/billchurch/ssh_test:debian
+    container_name: ssh-test-telnet
+    ports:
+      - "2237:22"
+      - "2323:23"
+    environment:
+      - SSH_USER=testuser
+      - SSH_PASSWORD=testpass123
+      - SSH_PERMIT_PASSWORD_AUTH=yes
+      - TELNET_ENABLED=yes
+      - TELNET_PORT=23
+      - SSH_DEBUG_LEVEL=1
+    restart: unless-stopped
+    profiles:
+      - telnet
+      - all
+
 volumes:
   dev-workspace:
     driver: local


### PR DESCRIPTION
## Summary

- Replaces `busybox-static` with `inetutils-telnetd` in the Debian Dockerfile for proper telnet protocol support
- Uses `socat` to listen on the telnet port and spawn `telnetd` with `nofork`, giving telnetd a real socket for `getpeername()` client address resolution
- Enables TERMINAL-TYPE negotiation (RFC 1091) for correct terminal handling
- Adds keyboard-interactive authentication documentation

## Test plan

- [ ] Build the Debian image: `make build`
- [ ] Run with telnet enabled: `make run-telnet`
- [ ] Verify telnet connection: `telnet localhost 2323`
- [ ] Confirm terminal type is negotiated correctly
- [ ] Verify SSH still works: `ssh -p 2222 testuser@localhost`